### PR TITLE
Loop bug fix

### DIFF
--- a/src/players/YouTube.js
+++ b/src/players/YouTube.js
@@ -65,9 +65,11 @@ export class YouTube extends Component {
         },
         ...embedOptions
       })
-      if (loop) {
-        this.player.setLoop(true) // Enable playlist looping
-      }
+       if (onReady) {
+          if (loop) {
+            this.player.setLoop(true); // Enable playlist looping
+          }
+        }
     }, onError)
   }
   onStateChange = ({ data }) => {


### PR DESCRIPTION
Seems the loop logic was firing before the player was ready. Wrapping line 68 with an an `if (onReady){...}` statement fixes the issue.